### PR TITLE
fix: allow compatibility with lazy.nvim

### DIFF
--- a/colors/lushwal.lua
+++ b/colors/lushwal.lua
@@ -3,7 +3,9 @@
 -- is the default), it will compile a new VimL color file.
 vim.cmd([[set background=dark]])
 vim.g.colors_name = "lushwal"
-vim.cmd([[packadd lush.nvim]])
+if not package.loaded["lazy"] then
+	vim.cmd([[packadd lush.nvim]])
+end
 require("lush")(require("lushwal").scheme)
 
 -- This makes sure we compile the vimscript scheme with any late added configuration variables (such as those set in a

--- a/lua/lushwal/base.lua
+++ b/lua/lushwal/base.lua
@@ -1,4 +1,6 @@
-vim.cmd("packadd lush.nvim")
+if not package.loaded["lazy"] then
+	vim.cmd("packadd lush.nvim")
+end
 local lush = require("lush")
 
 local colors = require("lushwal").colors

--- a/lua/lushwal/compile.lua
+++ b/lua/lushwal/compile.lua
@@ -31,15 +31,20 @@ end
 local function lushwal_compile()
 	local config = require("lushwal").config
 	if config.compile_to_vimscript then
-		vim.cmd([[packadd lush.nvim]])
-		vim.cmd([[packadd shipwright.nvim]])
+		if not package.loaded["lazy"] then
+			vim.cmd([[packadd lush.nvim]])
+			vim.cmd([[packadd shipwright.nvim]])
+		end
 		if vim.fn.exists(":Shipwright") ~= 0 then
 			local xdg = require("lushwal.utils.xdg")
 			local cache_path = xdg("XDG_CACHE_HOME") .. "/lushwal"
 			vim.fn.mkdir(cache_path, "p")
 			local fp = io.open(cache_path .. "/shipwright_build.lua", "w")
-			local script = [[vim.cmd("packadd shipwright.nvim")
-vim.cmd("packadd lush.nvim")
+			local script = [[
+if not package.loaded["lazy"] then
+	vim.cmd("packadd shipwright.nvim")
+	vim.cmd("packadd lush.nvim")
+end
 local xdg = require("lushwal.utils.xdg")
 local colorscheme = require("lushwal").scheme
 local lushwright = require("shipwright.transform.lush")

--- a/lua/lushwal/init.lua
+++ b/lua/lushwal/init.lua
@@ -48,7 +48,9 @@ local function run_hooks()
 end
 M.reload_colors = function()
 	local cfg = M.config
-	vim.cmd("packadd lush.nvim")
+	if not package.loaded["lazy"] then
+		vim.cmd("packadd lush.nvim")
+	end
 	colors = require("lushwal.colors")()
 	if type(cfg.color_overrides) == "function" then
 		local ok, c = pcall(cfg.color_overrides, colors)
@@ -77,7 +79,9 @@ setmetatable(M, {
 			end
 			return config
 		elseif key == "scheme" then
-			vim.cmd("packadd lush.nvim")
+			if not package.loaded["lazy"] then
+				vim.cmd("packadd lush.nvim")
+			end
 			local lush = require("lush")
 
 			local cfg = lushwal.config


### PR DESCRIPTION
By using `packadd`, the plugin manager `lazy.nvim` throws an error regarding not being able to find the plugin trying to be loaded. This happens because it already handles lazy loading.

To solve this issue, if-statements were added to all `packadd` calls with the condition that they will only be called if `lazy.nvim` is not loaded.