### PR TITLE
Update Readme.md to turn Lazy lazy load off

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -26,6 +26,7 @@ You can use `opt=true` because this plugin calls `packadd` when it needs lush an
 		{ "rktjmp/lush.nvim" },
 		{ "rktjmp/shipwright.nvim" },
 	},
+	lazy = false,
 }
 ```
 


### PR DESCRIPTION
This fixed lushwal.nvim for me, before it seemed the 'VimEnter' wouldn't fire, preventing updates.