### PR TITLE
Allow configuring wal colors.json path

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -58,6 +58,7 @@ Set `vim.g.lushwal_configuration` (in Lua) or `g:lushwal_configuration` (in Vims
 	compile_to_vimscript = true,
 	terminal_colors = false,
 	color_overrides = nil,
+	wal_path = vim.fn.expand("XDG_CACHE_HOME/wal/colors.json"),
 	addons = {
 		ale = false,
 		barbar = false,

--- a/lua/lushwal/colors.lua
+++ b/lua/lushwal/colors.lua
@@ -1,6 +1,7 @@
 -- luacheck: globals vim
 local hsl = require("lush").hsl
-local xdg = require("lushwal.utils.xdg")
+
+local config = require("lushwal").config
 
 -- Decode some JSON:
 local json_decode = function(data)
@@ -8,9 +9,8 @@ local json_decode = function(data)
 end
 
 -- Locate pywal cache:
-local wal_path = xdg("XDG_CACHE_HOME") .. "/wal/colors.json"
 local function generate_colors()
-	local ok, colors = json_decode(vim.fn.readfile(wal_path))
+	local ok, colors = json_decode(vim.fn.readfile(config.wal_path))
 
 	-- Generate Color Variables:
 	if ok then
@@ -71,13 +71,13 @@ local function generate_colors()
 			br_cyan = color14,
 			br_white = color15,
 			-- Special colors:
-			grey = color8.mix(color7, 30),          -- Darker mid-grey
-			br_grey = color8.mix(color7, 65),       -- Mid-grey
+			grey = color8.mix(color7, 30),             -- Darker mid-grey
+			br_grey = color8.mix(color7, 65),          -- Mid-grey
 			orange = color1.mix(color3, 50),
-			purple = color4.rotate(65).li(45),      -- Purple
+			purple = color4.rotate(65).li(45),         -- Purple
 			pink = color4.rotate(65).li(45).mix(color5, 50), -- Pink
 			amaranth = color1.mix(color4, 34).saturate(46).darken(5),
-			brown = color1.mix(color5, 15),         -- Brown
+			brown = color1.mix(color5, 15),            -- Brown
 		}
 	else
 		return nil

--- a/lua/lushwal/config.lua
+++ b/lua/lushwal/config.lua
@@ -1,8 +1,11 @@
 -- luacheck: globals vim
+local xdg = require("lushwal.utils.xdg")
+
 return {
 	transparent_background = false,
 	compile_to_vimscript = true,
 	terminal_colors = false,
+	wal_path = xdg("XDG_CACHE_HOME") .. "/wal/colors.json",
 	addons = {
 		ale = false,
 		barbar = false,

--- a/lua/lushwal/init.lua
+++ b/lua/lushwal/init.lua
@@ -19,11 +19,10 @@ M.compile_if_stale = function()
 		return s.mtime.sec
 	end
 	local our_path = xdg("XDG_CONFIG_HOME") .. "/nvim/colors/lushwal.vim"
-	local wal_path = xdg("XDG_CACHE_HOME") .. "/wal/colors.json"
 	-- fs_stat will return nil for missing files, you could also check
 	-- specifically for stat, errmsg, code  where code == "ENOENT" for missing
 	-- files, vs unreadable but it probably doesn't matter most of the time.
-	local wal_stats = uv.fs_stat(wal_path)
+	local wal_stats = uv.fs_stat(config.wal_path)
 	local our_stats = uv.fs_stat(our_path)
 	if (wal_stats and not our_stats) or (wal_stats and our_stats and mtime(our_stats) < mtime(wal_stats)) then
 		-- have wal-file but no compiled output or have both but ours is older
@@ -38,7 +37,7 @@ M.add_reload_hook = function(callback)
 	table.insert(hooks, callback)
 end
 local function run_hooks()
-	for _,hook in pairs(hooks) do
+	for _, hook in pairs(hooks) do
 		if type(hook) == "string" then
 			vim.cmd(hook)
 		elseif type(hook) == "function" then
@@ -84,24 +83,24 @@ setmetatable(M, {
 
 			-- Set terminal colors if set to true in config
 			if cfg.terminal_colors == true then
-					local convert = require("lush.vivid.hsl.convert")
-					-- Set terminal colors
-					vim.g.terminal_color_0 = convert.hsl_to_hex(colors.color0)
-					vim.g.terminal_color_1 = convert.hsl_to_hex(colors.color1)
-					vim.g.terminal_color_2 = convert.hsl_to_hex(colors.color2)
-					vim.g.terminal_color_3 = convert.hsl_to_hex(colors.color3)
-					vim.g.terminal_color_4 = convert.hsl_to_hex(colors.color4)
-					vim.g.terminal_color_5 = convert.hsl_to_hex(colors.color5)
-					vim.g.terminal_color_6 = convert.hsl_to_hex(colors.color6)
-					vim.g.terminal_color_7 = convert.hsl_to_hex(colors.color7)
-					vim.g.terminal_color_8 = convert.hsl_to_hex(colors.color8)
-					vim.g.terminal_color_9 = convert.hsl_to_hex(colors.color9)
-					vim.g.terminal_color_10 = convert.hsl_to_hex(colors.color10)
-					vim.g.terminal_color_11 = convert.hsl_to_hex(colors.color11)
-					vim.g.terminal_color_12 = convert.hsl_to_hex(colors.color12)
-					vim.g.terminal_color_13 = convert.hsl_to_hex(colors.color13)
-					vim.g.terminal_color_14 = convert.hsl_to_hex(colors.color14)
-					vim.g.terminal_color_15 = convert.hsl_to_hex(colors.color15)
+				local convert = require("lush.vivid.hsl.convert")
+				-- Set terminal colors
+				vim.g.terminal_color_0 = convert.hsl_to_hex(colors.color0)
+				vim.g.terminal_color_1 = convert.hsl_to_hex(colors.color1)
+				vim.g.terminal_color_2 = convert.hsl_to_hex(colors.color2)
+				vim.g.terminal_color_3 = convert.hsl_to_hex(colors.color3)
+				vim.g.terminal_color_4 = convert.hsl_to_hex(colors.color4)
+				vim.g.terminal_color_5 = convert.hsl_to_hex(colors.color5)
+				vim.g.terminal_color_6 = convert.hsl_to_hex(colors.color6)
+				vim.g.terminal_color_7 = convert.hsl_to_hex(colors.color7)
+				vim.g.terminal_color_8 = convert.hsl_to_hex(colors.color8)
+				vim.g.terminal_color_9 = convert.hsl_to_hex(colors.color9)
+				vim.g.terminal_color_10 = convert.hsl_to_hex(colors.color10)
+				vim.g.terminal_color_11 = convert.hsl_to_hex(colors.color11)
+				vim.g.terminal_color_12 = convert.hsl_to_hex(colors.color12)
+				vim.g.terminal_color_13 = convert.hsl_to_hex(colors.color13)
+				vim.g.terminal_color_14 = convert.hsl_to_hex(colors.color14)
+				vim.g.terminal_color_15 = convert.hsl_to_hex(colors.color15)
 			end
 
 			package.loaded["lushwal.base"] = nil

--- a/lua/lushwal/watcher.lua
+++ b/lua/lushwal/watcher.lua
@@ -70,9 +70,8 @@ local function on_change(_, _, _)
 	end, 1)
 end
 function watch_file()
-	local wal_path = xdg("XDG_CACHE_HOME") .. "/wal/colors.json"
 	w:start(
-		wal_path,
+		require("lushwal").config.wal_path,
 		{},
 		vim.schedule_wrap(function(...)
 			on_change(...)


### PR DESCRIPTION
This is useful for me, because I use a different tool to generate `colors.json`